### PR TITLE
fix: Update link data correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           deno-version: ${{ env.DENO_VERSION }}
       - name: Check fmt & lint & type check & test
-        run: deno task check:dry
+        run: deno task fix

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,4 +1,3 @@
-# ported from https://github.com/jsr-core/unknownutil/blob/v3.18.1/.github/workflows/udd.yml and modified a bit
 name: Update
 
 on:
@@ -7,10 +6,10 @@ on:
   workflow_dispatch:
 
 env:
-  DENO_VERSION: 1.x
+  DENO_VERSION: 2.x
 
 jobs:
-  udd:
+  update:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -19,7 +18,7 @@ jobs:
           deno-version: ${{ env.DENO_VERSION }}
       - name: Update dependencies
         run: |
-          deno task update > ../output.txt
+          deno outdated --update > ../output.txt
         env:
           NO_COLOR: 1
       - name: Read ../output.txt
@@ -27,12 +26,12 @@ jobs:
         uses: juliangruber/read-file-action@v1
         with:
           path: ../output.txt
-      - uses: peter-evans/create-pull-request@v6
+      - uses: peter-evans/create-pull-request@v7
         with:
-          commit-message: ":package: Update Deno dependencies"
-          title: ":package: Update Deno dependencies"
+          commit-message: "chore: Update Deno dependencies"
+          title: "chore: Update Deno dependencies"
           body: |
-            The output of `deno task update` is
+            The output of `deno outdated --update` is
 
             ```
             ${{ steps.log.outputs.content }}

--- a/db.ts
+++ b/db.ts
@@ -9,7 +9,7 @@ let db: IDBPDatabase<SchemaV2>;
 
 /** DBを取得する。まだ開いていなければ一度だけ開く */
 export const open = async (): Promise<IDBPDatabase<SchemaV2>> => {
-  db ??= await openDB<SchemaV2>("scrapbox-storage", 2, {
+  db ??= await openDB<SchemaV2>("scrapbox-storage-test", 2, {
     upgrade(db) {
       logger.time("update DB");
 
@@ -19,7 +19,6 @@ export const open = async (): Promise<IDBPDatabase<SchemaV2>> => {
 
       const titles = db.createObjectStore("titles", { keyPath: "id" });
       titles.createIndex("project", "project");
-      titles.createIndex("updated", "updated");
 
       const projects = db.createObjectStore("projects", {
         keyPath: "name",

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -5,7 +5,6 @@
   "tasks": {
     "fix": "deno fmt && deno lint --fix && deno doc --lint mod.ts && deno check --remote **/*.ts && deno publish --dry-run --allow-dirty",
     "check": "deno fmt --check && deno lint && deno doc --lint mod.ts && deno check --remote **/*.ts && deno publish --dry-run --allow-dirty",
-    "publish:check": "deno task check:dry && deno publish --dry-run --allow-dirty",
     "publish": "deno run --allow-env --allow-run=deno --allow-read --allow-write=deno.jsonc jsr:@david/publish-on-tag@0.1.x"
   },
   "imports": {

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -3,20 +3,18 @@
   "version": "0.0.0",
   "exports": "./mod.ts",
   "tasks": {
-    "check": "deno fmt && deno lint --fix && deno check --remote **/*.ts",
-    "check:dry": "deno fmt --check && deno lint && deno check --remote **/*.ts",
-    "update:check": "deno run --allow-env --allow-read --allow-write=.,'~/.local/share/deno-wasmbuild' --allow-run=git,deno --allow-net=deno.land,raw.githubusercontent.com,esm.sh,jsr.io,registry.npmjs.org,api.jsr.io jsr:@molt/cli@0.19",
-    "update": "deno task update:check --write",
+    "fix": "deno fmt && deno lint --fix && deno doc --lint mod.ts && deno check --remote **/*.ts && deno publish --dry-run --allow-dirty",
+    "check": "deno fmt --check && deno lint && deno doc --lint mod.ts && deno check --remote **/*.ts && deno publish --dry-run --allow-dirty",
     "publish:check": "deno task check:dry && deno publish --dry-run --allow-dirty",
     "publish": "deno run --allow-env --allow-run=deno --allow-read --allow-write=deno.jsonc jsr:@david/publish-on-tag@0.1.x"
   },
   "imports": {
-    "@cosense/std": "jsr:@cosense/std@^0.29.0",
+    "@cosense/std": "jsr:@cosense/std@0.29",
     "@cosense/types": "jsr:@cosense/types@0.10",
     "@takker/debug-js": "jsr:@takker/debug-js@0.1",
     "idb": "npm:idb@8",
     "date-fns": "npm:date-fns@4",
-    "option-t": "npm:option-t@50"
+    "option-t": "npm:option-t@^50.0.1"
   },
   "compilerOptions": {
     "lib": [

--- a/deno.lock
+++ b/deno.lock
@@ -2,32 +2,44 @@
   "version": "4",
   "specifiers": {
     "jsr:@core/unknownutil@4": "4.3.0",
-    "jsr:@cosense/std@0.29": "0.29.1",
+    "jsr:@cosense/std@0.29": "0.29.2",
     "jsr:@cosense/types@0.10": "0.10.1",
+    "jsr:@progfay/scrapbox-parser@9": "9.1.5",
+    "jsr:@std/async@1": "1.0.9",
     "jsr:@std/encoding@1": "1.0.5",
     "jsr:@takker/debug-js@0.1": "0.1.2",
     "jsr:@takker/md5@0.1": "0.1.0",
     "npm:date-fns@4": "4.1.0",
     "npm:idb@8": "8.0.0",
     "npm:option-t@50": "50.0.0",
-    "npm:option-t@^49.1.0": "49.3.0"
+    "npm:option-t@^50.0.1": "50.0.1",
+    "npm:socket.io-client@^4.7.5": "4.8.1"
   },
   "jsr": {
     "@core/unknownutil@4.3.0": {
       "integrity": "538a3687ffa81028e91d148818047df219663d0da671d906cecd165581ae55cc"
     },
-    "@cosense/std@0.29.1": {
-      "integrity": "797c393fe9874079d42b18055c0c1b754e1d771f29c0dd2d21f9d8530b618ae6",
+    "@cosense/std@0.29.2": {
+      "integrity": "668d473666b38cf8320394dfb96d31625b3856716f591671687d245af211f3d4",
       "dependencies": [
         "jsr:@core/unknownutil",
         "jsr:@cosense/types",
+        "jsr:@progfay/scrapbox-parser",
+        "jsr:@std/async",
         "jsr:@std/encoding",
         "jsr:@takker/md5",
-        "npm:option-t@^49.1.0"
+        "npm:option-t@50",
+        "npm:socket.io-client"
       ]
     },
     "@cosense/types@0.10.1": {
       "integrity": "13d2488a02c7b0b035a265bc3299affbdab1ea5b607516379685965cd37b2058"
+    },
+    "@progfay/scrapbox-parser@9.1.5": {
+      "integrity": "729a086b6675dd4a216875757c918c6bbea329d6e35e410516a16bbd6c468369"
+    },
+    "@std/async@1.0.9": {
+      "integrity": "c6472fd0623b3f3daae023cdf7ca5535e1b721dfbf376562c0c12b3fb4867f91"
     },
     "@std/encoding@1.0.5": {
       "integrity": "ecf363d4fc25bd85bd915ff6733a7e79b67e0e7806334af15f4645c569fefc04"
@@ -40,17 +52,64 @@
     }
   },
   "npm": {
+    "@socket.io/component-emitter@3.1.2": {
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="
+    },
     "date-fns@4.1.0": {
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="
+    },
+    "debug@4.3.7": {
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dependencies": [
+        "ms"
+      ]
+    },
+    "engine.io-client@6.6.2": {
+      "integrity": "sha512-TAr+NKeoVTjEVW8P3iHguO1LO6RlUz9O5Y8o7EY0fU+gY1NYqas7NN3slpFtbXEsLMHk0h90fJMfKjRkQ0qUIw==",
+      "dependencies": [
+        "@socket.io/component-emitter",
+        "debug",
+        "engine.io-parser",
+        "ws",
+        "xmlhttprequest-ssl"
+      ]
+    },
+    "engine.io-parser@5.2.3": {
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q=="
     },
     "idb@8.0.0": {
       "integrity": "sha512-l//qvlAKGmQO31Qn7xdzagVPPaHTxXx199MhrAFuVBTPqydcPYBWjkrbv4Y0ktB+GmWOiwHl237UUOrLmQxLvw=="
     },
-    "option-t@49.3.0": {
-      "integrity": "sha512-MQFSbqNnjEzQahREx7r1tESmK2UctFK+zmwmnHpBHROJvoRGM9tDMWi53B6ePyFJyAiggRRV9cuXedkpLBeC8w=="
+    "ms@2.1.3": {
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "option-t@50.0.0": {
       "integrity": "sha512-zHw9Et+SfAx3Xtl9LagyAjyyzC3pNONEinTAOmZN2IKL0dYa6dthjzwuSRueJ2gLkaTiinQjRDGo/1mKSl70hg=="
+    },
+    "option-t@50.0.1": {
+      "integrity": "sha512-QZkAjLrO0fY8DICD0tXJtjnsd7wGjgDDyPOvRf+bmIZAwAt98V0TiQ2JqN9gElAxHw2Dz376lPrZtvimcBGAbA=="
+    },
+    "socket.io-client@4.8.1": {
+      "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
+      "dependencies": [
+        "@socket.io/component-emitter",
+        "debug",
+        "engine.io-client",
+        "socket.io-parser"
+      ]
+    },
+    "socket.io-parser@4.2.4": {
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "dependencies": [
+        "@socket.io/component-emitter",
+        "debug"
+      ]
+    },
+    "ws@8.17.1": {
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ=="
+    },
+    "xmlhttprequest-ssl@2.1.2": {
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ=="
     }
   },
   "workspace": {
@@ -60,7 +119,7 @@
       "jsr:@takker/debug-js@0.1",
       "npm:date-fns@4",
       "npm:idb@8",
-      "npm:option-t@50"
+      "npm:option-t@^50.0.1"
     ]
   }
 }

--- a/link.ts
+++ b/link.ts
@@ -1,4 +1,5 @@
 import type { SearchedTitle } from "@cosense/types/rest";
+export type { SearchedTitle };
 
 /** link data */
 export interface Link extends SearchedTitle {

--- a/schema-v2.ts
+++ b/schema-v2.ts
@@ -11,7 +11,6 @@ export interface SchemaV2 extends DBSchema {
     key: string;
     indexes: {
       project: string;
-      updated: number;
     };
   };
 

--- a/subscribe.ts
+++ b/subscribe.ts
@@ -1,9 +1,13 @@
 import type { Link } from "./link.ts";
 
+/**
+ * A type representing a function that listens for {@linkcode LinkEvent} events.
+ */
 export type Listener = (event: LinkEvent) => void;
 
 /** リンク更新時に送られるイベント */
 export interface LinkEvent {
+  /** event type */
   type: "links:changed";
   /** 更新されたproject */
   project: string;
@@ -11,26 +15,30 @@ export interface LinkEvent {
   diff: Diff;
 }
 
+/**
+ * Represents the differences between two sets of pages.
+ */
 export interface Diff {
-  /** added pages
+  /**
+   * Pages that have been added.
    *
-   * key is page id
+   * The key is the page ID, and the value is the link data for the added page.
    */
-  added: Map<string, Link>;
+  added?: Map<string, Link>;
 
-  /** updated pages
+  /**
+   * Pages that have been updated.
    *
-   * key is page id
-   *
-   * the value is a tuple of old and new link data
+   * The key is the page ID, and the value is a tuple containing the old and new link data for the updated page.
    */
-  updated: Map<string, [Link, Link]>;
+  updated?: Map<string, [Link, Link]>;
 
-  /** deleted page ids
+  /**
+   * Pages that have been deleted.
    *
-   * key is page id
+   * The key is the page ID, and the value is the link data for the deleted page.
    */
-  deleted: Map<string, Link>;
+  deleted?: Map<string, Link>;
 }
 
 /** リンクデータの更新を購読する
@@ -52,6 +60,10 @@ export const subscribe = (
 
 /** リンクデータの更新を通知する */
 export const emitChange = (project: string, diff: Diff): void => {
+  if (
+    (diff.added?.size ?? 0) + (diff.updated?.size ?? 0) +
+        (diff.deleted?.size ?? 0) === 0
+  ) return;
   const event: LinkEvent = { type: "links:changed", project, diff };
   emitChangeToListeners(event);
   const bc = new BroadcastChannel(notifyChannelName);


### PR DESCRIPTION
Link dataの更新アルゴリズムを間違えていた。

DB構造に少し修正を加えつつ、正常に更新されるように直した。

その他
- Deno v2を使う
- `deno doc --lint`をpassした
- `BroadcastChannel`には、DBへリンクデータの更新を反映するたびに通知する
- 更新がないときは通知しない